### PR TITLE
Fix build warnings in API and frontend

### DIFF
--- a/apps/api/vite.config.ts
+++ b/apps/api/vite.config.ts
@@ -18,6 +18,9 @@ export default defineConfig({
     }),
     tsconfigPaths(),
   ],
+  optimizeDeps: {
+    exclude: ["mock-aws-s3", "aws-sdk", "nock"],
+  },
   resolve: {
     preserveSymlinks: false,
   },
@@ -26,6 +29,7 @@ export default defineConfig({
       output: {
         format: "esm",
       },
+      external: ["mock-aws-s3", "aws-sdk", "nock"],
     },
   },
 });

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,7 +3,18 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [remix(), tsconfigPaths()],
+  plugins: [
+    remix({
+      future: {
+        v3_fetcherPersist: true,
+        v3_lazyRouteDiscovery: true,
+        v3_relativeSplatPath: true,
+        v3_singleFetch: true,
+        v3_throwAbortReason: true,
+      },
+    }),
+    tsconfigPaths(),
+  ],
   server: {
     port: Number(process.env.PORT) || 3000,
   },


### PR DESCRIPTION
## Summary
- Fixed API bundling errors by excluding AWS dependencies from esbuild optimization
- Added React Router v7 future flags to suppress frontend warnings
- Configured Vite to externalize mock-aws-s3, aws-sdk, and nock packages

## Changes
- **API**: Added `optimizeDeps.exclude` and `rollupOptions.external` for AWS packages
- **Frontend**: Added all React Router v7 future flags to remix configuration

## Test plan
- [x] `yarn dev` runs without AWS bundling errors
- [x] Frontend starts without React Router v7 warnings
- [x] Both API and frontend serve correctly